### PR TITLE
fix(terra-draw): fix package name to match the prefixed ones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@blocktype-co-uk/terra-draw",
+	"name": "@blocktype-co-uk/terra-draw-monorepo",
 	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@blocktype-co-uk/terra-draw",
+			"name": "@blocktype-co-uk/terra-draw-monorepo",
 			"version": "1.0.0",
 			"workspaces": [
 				"packages/*"
@@ -2071,6 +2071,14 @@
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@blocktype-co-uk/terra-draw": {
+			"resolved": "packages/terra-draw",
+			"link": true
+		},
+		"node_modules/@blocktype-co-uk/terra-draw-maplibre-gl-adapter": {
+			"resolved": "packages/terra-draw-maplibre-gl-adapter",
+			"link": true
 		},
 		"node_modules/@commitlint/cli": {
 			"version": "17.1.2",
@@ -22256,10 +22264,6 @@
 			"resolved": "packages/terra-draw-mapbox-gl-adapter",
 			"link": true
 		},
-		"node_modules/terra-draw-maplibre-gl-adapter": {
-			"resolved": "packages/terra-draw-maplibre-gl-adapter",
-			"link": true
-		},
 		"node_modules/terra-draw-openlayers-adapter": {
 			"resolved": "packages/terra-draw-openlayers-adapter",
 			"link": true
@@ -25258,6 +25262,12 @@
 				"node": ">=4.0"
 			}
 		},
+		"packages/e2e/node_modules/terra-draw": {
+			"version": "1.14.0",
+			"resolved": "https://registry.npmjs.org/terra-draw/-/terra-draw-1.14.0.tgz",
+			"integrity": "sha512-IEXwUObdQDpZVsL8tW2TW5M+V6FHuHt8GePkkaW4TsLQ0Jj1MJ7VyCY6DVFWhAe4meygzlLah+mPNMBgNomxwA==",
+			"license": "MIT"
+		},
 		"packages/e2e/node_modules/undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -25354,7 +25364,8 @@
 			}
 		},
 		"packages/terra-draw": {
-			"version": "1.14.0",
+			"name": "@blocktype-co-uk/terra-draw",
+			"version": "1.14.1",
 			"license": "MIT"
 		},
 		"packages/terra-draw-arcgis-adapter": {
@@ -25396,11 +25407,12 @@
 			}
 		},
 		"packages/terra-draw-maplibre-gl-adapter": {
+			"name": "@blocktype-co-uk/terra-draw-maplibre-gl-adapter",
 			"version": "1.1.2",
 			"license": "MIT",
 			"peerDependencies": {
-				"maplibre-gl": ">=4",
-				"terra-draw": "^1.0.0"
+				"@blocktype-co-uk/terra-draw": "^1.0.0",
+				"maplibre-gl": ">=4"
 			}
 		},
 		"packages/terra-draw-openlayers-adapter": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@blocktype-co-uk/terra-draw",
+	"name": "@blocktype-co-uk/terra-draw-monorepo",
 	"version": "1.0.0",
 	"description": "The monorepo for all core Terra Draw packages",
 	"private": true,

--- a/packages/terra-draw-maplibre-gl-adapter/package.json
+++ b/packages/terra-draw-maplibre-gl-adapter/package.json
@@ -1,9 +1,9 @@
 {
-	"name": "terra-draw-maplibre-gl-adapter",
+	"name": "@blocktype-co-uk/terra-draw-maplibre-gl-adapter",
 	"version": "1.1.2",
 	"description": "Terra Draw Adapter for Maplibre GL JS",
 	"peerDependencies": {
-		"terra-draw": "^1.0.0",
+		"@blocktype-co-uk/terra-draw": "^1.0.0",
 		"maplibre-gl": ">=4"
 	},
 	"scripts": {
@@ -36,7 +36,10 @@
 	"unpkg": "./dist/terra-draw-maplibre-gl-adapter.umd.js",
 	"author": "James Milner",
 	"license": "MIT",
-	"repository": "JamesLMilner/terra-draw",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/blocktype-co-uk/terra-draw.git"
+	},
 	"keywords": [
 		"map",
 		"drawing",

--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
@@ -7,7 +7,7 @@ import {
 	TerraDrawStylingFunction,
 	TerraDrawExtend,
 	GeoJSONStoreGeometries,
-} from "terra-draw";
+} from "@blocktype-co-uk/terra-draw";
 import {
 	CircleLayerSpecification,
 	FillLayerSpecification,

--- a/packages/terra-draw/package.json
+++ b/packages/terra-draw/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "terra-draw",
-	"version": "1.14.0",
+	"name": "@blocktype-co-uk/terra-draw",
+	"version": "1.14.1",
 	"description": "Frictionless map drawing across mapping provider",
 	"scripts": {
 		"release": "TYPE=$(node ../../bump.mjs) && commit-and-tag-version .versionrc.cjs -t terra-draw@ --release-as $TYPE",
@@ -32,7 +32,10 @@
 	"unpkg": "./dist/terra-draw.umd.js",
 	"author": "James Milner",
 	"license": "MIT",
-	"repository": "JamesLMilner/terra-draw",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/blocktype-co-uk/terra-draw.git"
+	},
 	"keywords": [
 		"map",
 		"drawing",


### PR DESCRIPTION
I didn't realised I missed this until building the packages. The packages we use need the prefix and to be correctly referenced by the adapters.