### PR TITLE
fix(terra-draw): set zIndex property on polygon creation

### DIFF
--- a/packages/terra-draw/src/modes/polygon/polygon.mode.ts
+++ b/packages/terra-draw/src/modes/polygon/polygon.mode.ts
@@ -641,6 +641,19 @@ export class TerraDrawPolygonMode extends TerraDrawBaseDrawMode<PolygonStyling> 
 			this.currentId = newId;
 			this.currentCoordinate++;
 
+			// set zIndex property if given. This is used to sort the polygons when choosing which one to select on click
+			if (this.styles.zIndex) {
+				const feature = this.store.copy(newId);
+				if (feature) {
+					const value = this.getNumericStylingValue(
+						this.styles.zIndex,
+						0,
+						feature,
+					);
+					this.store.updateProperty([{ id: newId, property: "zIndex", value }]);
+				}
+			}
+
 			if (this.showCoordinatePoints) {
 				this.coordinatePoints.createOrUpdate(newId);
 			}


### PR DESCRIPTION
Last backported change that I thought it wasn't needed anymore, but actually still is! Ensures that the zIndex is set after creating a polygon from the drawing mode. Otherwise it'll only work once all the polygons are reloaded. 