### PR TITLE
feat(terra-draw): add pointer on selected point option

### DIFF
--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -63,6 +63,7 @@ export type SetCursor = (
 		| "crosshair"
 		| "pointer"
 		| "wait"
+		| "default"
 		| "move",
 ) => void;
 

--- a/packages/terra-draw/src/modes/select/select.mode.ts
+++ b/packages/terra-draw/src/modes/select/select.mode.ts
@@ -108,6 +108,7 @@ type SelectionStyling = {
 };
 
 interface Cursors {
+	pointerOverSelectionPoint?: Cursor;
 	pointerOver?: Cursor;
 	dragStart?: Cursor;
 	dragEnd?: Cursor;
@@ -115,6 +116,7 @@ interface Cursors {
 }
 
 const defaultCursors = {
+	pointerOverSelectionPoint: "move",
 	pointerOver: "move",
 	dragStart: "move",
 	dragEnd: "move",
@@ -955,6 +957,14 @@ export class TerraDrawSelectMode extends TerraDrawBaseSelectMode<SelectionStylin
 		// If we have a feature under the pointer then show the pointer over cursor
 		const { clickedFeature: featureUnderPointer } =
 			this.featuresAtMouseEvent.find(event, true);
+
+		if (
+			featureUnderPointer?.geometry.type !== "Point" &&
+			nearbySelectionPoint
+		) {
+			this.setCursor(this.cursors.pointerOverSelectionPoint);
+			return;
+		}
 
 		if (
 			this.selected.length > 0 &&

--- a/packages/terra-draw/src/terra-draw.extensions.spec.ts
+++ b/packages/terra-draw/src/terra-draw.extensions.spec.ts
@@ -132,6 +132,7 @@ export class TerraDrawTestAdapter extends TerraDrawBaseAdapter {
 		_:
 			| "move"
 			| "unset"
+			| "default"
 			| "grab"
 			| "grabbing"
 			| "crosshair"


### PR DESCRIPTION
Allows the pointer to be of type default and adds an additional config so that a vertex of a feature can have a different cursor when hovered