### PR TITLE
feat(terra-draw-maplibre-gl-adapter): preserve map draggability

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
@@ -131,76 +131,99 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 	});
 
 	describe("setDraggability", () => {
-		it("setDraggability enables and disables map dragging", () => {
-			const map = createMapLibreGLMap();
+		describe("when disabling first", () => {
+			it("setDraggability disables and re-enables map dragging", () => {
+				// drag pan and rotate are enabled by default
+				const map = createMapLibreGLMap();
 
-			const adapter = new TerraDrawMapLibreGLAdapter({
-				map: map as maplibregl.Map,
+				const adapter = new TerraDrawMapLibreGLAdapter({
+					map: map as maplibregl.Map,
+				});
+
+				// Test disabling dragging
+				adapter.setDraggability(false);
+				expect(map.dragPan?.enable).toHaveBeenCalledTimes(0);
+				expect(map.dragPan?.disable).toHaveBeenCalledTimes(1);
+				expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
+				expect(map.dragRotate?.disable).toHaveBeenCalledTimes(1);
+
+				// Test enabling dragging
+				adapter.setDraggability(true);
+				expect(map.dragPan?.enable).toHaveBeenCalledTimes(1);
+				expect(map.dragPan?.disable).toHaveBeenCalledTimes(1); // from setDraggability(false)
+				expect(map.dragRotate?.enable).toHaveBeenCalledTimes(1);
+				expect(map.dragRotate?.disable).toHaveBeenCalledTimes(1); // from setDraggability(false)
 			});
 
-			// Test enabling dragging
-			adapter.setDraggability(true);
-			expect(map.dragPan?.enable).toHaveBeenCalledTimes(1);
-			expect(map.dragPan?.disable).toHaveBeenCalledTimes(0);
-			expect(map.dragRotate?.enable).toHaveBeenCalledTimes(1);
-			expect(map.dragRotate?.disable).toHaveBeenCalledTimes(0);
+			it("respects mixed pan/rotate settings when calling setDraggability", () => {
+				const map = createMapLibreGLMap();
 
-			// Test disabling dragging
-			adapter.setDraggability(false);
-			expect(map.dragPan?.enable).toHaveBeenCalledTimes(1);
-			expect(map.dragPan?.disable).toHaveBeenCalledTimes(1);
-			expect(map.dragRotate?.enable).toHaveBeenCalledTimes(1);
-			expect(map.dragRotate?.disable).toHaveBeenCalledTimes(1);
+				// we expect it to disable both, but only re-enable drag pan
+				map.dragPan!.isEnabled = jest.fn(() => true);
+				map.dragRotate!.isEnabled = jest.fn(() => false);
+
+				const adapter = new TerraDrawMapLibreGLAdapter({
+					map: map as maplibregl.Map,
+				});
+
+				// Test disabling dragging
+				adapter.setDraggability(false);
+				expect(map.dragPan?.disable).toHaveBeenCalledTimes(1);
+				expect(map.dragPan?.enable).toHaveBeenCalledTimes(0);
+				expect(map.dragRotate?.disable).toHaveBeenCalledTimes(1);
+				expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
+
+				// Test enabling dragging
+				adapter.setDraggability(true);
+				expect(map.dragPan?.disable).toHaveBeenCalledTimes(1);
+				expect(map.dragPan?.enable).toHaveBeenCalledTimes(1);
+				expect(map.dragRotate?.disable).toHaveBeenCalledTimes(1);
+				expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
+			});
+
+			describe("and the map was previously not dragable", () => {
+				it("it does not re-enable pan/rotate settings", () => {
+					const map = createMapLibreGLMap();
+					map.dragPan!.isEnabled = jest.fn(() => false);
+					map.dragRotate!.isEnabled = jest.fn(() => false);
+
+					const adapter = new TerraDrawMapLibreGLAdapter({
+						map: map as maplibregl.Map,
+					});
+
+					// Test enabling dragging
+					adapter.setDraggability(false);
+					expect(map.dragPan?.enable).toHaveBeenCalledTimes(0);
+					expect(map.dragPan?.disable).toHaveBeenCalledTimes(1);
+					expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
+					expect(map.dragRotate?.disable).toHaveBeenCalledTimes(1);
+
+					// Test re-enabling dragging
+					adapter.setDraggability(true);
+					expect(map.dragPan?.enable).toHaveBeenCalledTimes(0);
+					expect(map.dragPan?.disable).toHaveBeenCalledTimes(1);
+					expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
+					expect(map.dragRotate?.disable).toHaveBeenCalledTimes(1);
+				});
+			});
 		});
 
-		it("respects original pan/rotate settings when calling setDraggability", () => {
-			const map = createMapLibreGLMap();
+		describe("when enabling first", () => {
+			it("it does nothing", () => {
+				const map = createMapLibreGLMap();
+				map.dragPan!.isEnabled = jest.fn(() => false);
+				map.dragRotate!.isEnabled = jest.fn(() => false);
 
-			map.dragPan!.isEnabled = jest.fn(() => false);
-			map.dragRotate!.isEnabled = jest.fn(() => false);
+				const adapter = new TerraDrawMapLibreGLAdapter({
+					map: map as maplibregl.Map,
+				});
 
-			const adapter = new TerraDrawMapLibreGLAdapter({
-				map: map as maplibregl.Map,
+				adapter.setDraggability(true);
+				expect(map.dragPan?.enable).toHaveBeenCalledTimes(0);
+				expect(map.dragPan?.disable).toHaveBeenCalledTimes(0);
+				expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
+				expect(map.dragRotate?.disable).toHaveBeenCalledTimes(0);
 			});
-
-			// Test enabling dragging
-			adapter.setDraggability(true);
-			expect(map.dragPan?.enable).toHaveBeenCalledTimes(0);
-			expect(map.dragPan?.disable).toHaveBeenCalledTimes(0);
-			expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
-			expect(map.dragRotate?.disable).toHaveBeenCalledTimes(0);
-
-			// Test disabling dragging
-			adapter.setDraggability(false);
-			expect(map.dragPan?.enable).toHaveBeenCalledTimes(0);
-			expect(map.dragPan?.disable).toHaveBeenCalledTimes(0);
-			expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
-			expect(map.dragRotate?.disable).toHaveBeenCalledTimes(0);
-		});
-
-		it("respects mixed pan/rotate settings when calling setDraggability", () => {
-			const map = createMapLibreGLMap();
-
-			map.dragPan!.isEnabled = jest.fn(() => true);
-			map.dragRotate!.isEnabled = jest.fn(() => false);
-
-			const adapter = new TerraDrawMapLibreGLAdapter({
-				map: map as maplibregl.Map,
-			});
-
-			// Test enabling dragging
-			adapter.setDraggability(true);
-			expect(map.dragPan?.enable).toHaveBeenCalledTimes(1);
-			expect(map.dragPan?.disable).toHaveBeenCalledTimes(0);
-			expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
-			expect(map.dragRotate?.disable).toHaveBeenCalledTimes(0);
-
-			// Test disabling dragging
-			adapter.setDraggability(false);
-			expect(map.dragPan?.enable).toHaveBeenCalledTimes(1);
-			expect(map.dragPan?.disable).toHaveBeenCalledTimes(1);
-			expect(map.dragRotate?.enable).toHaveBeenCalledTimes(0);
-			expect(map.dragRotate?.disable).toHaveBeenCalledTimes(0);
 		});
 	});
 


### PR DESCRIPTION
## Description of Changes

Changes in https://github.com/JamesLMilner/terra-draw/pull/504 meant that the state of `dragPan` and `dragRotate` at _adapter instantiation time_ would be respected when terra-draw manages map draggability. However, if you change map draggability outside of terra-draw _after_ the adapter is instantiated, then it would not respect that updated value.

This change makes the assumption that terra-draw will always attempt to disable map interactions (in order to handle dragging drawn features), and then re-enable it later. We use that as a way to determine when to snapshot/restore the external map drag values.