### PR TITLE
feat(terra-draw-maplibre-gl-adapter): preserve initial cursor

### DIFF
--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
@@ -280,6 +280,29 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 			expect(map.getCanvas).toHaveBeenCalledTimes(2);
 			expect(container.style.cursor).toBe("pointer");
 		});
+
+		describe("when a cursor is set and then unset", () => {
+			it("restores the initial cursor", () => {
+				const map = createMapLibreGLMap();
+				const adapter = new TerraDrawMapLibreGLAdapter({
+					map: map as maplibregl.Map,
+				});
+
+				const container = {
+					offsetLeft: 0,
+					offsetTop: 0,
+					style: { removeProperty: jest.fn(), cursor: "initial" },
+				} as unknown as HTMLCanvasElement;
+
+				map.getCanvas = jest.fn(() => container);
+
+				adapter.setCursor("pointer");
+				expect(container.style.cursor).toBe("pointer");
+
+				adapter.setCursor("unset");
+				expect(container.style.cursor).toBe("initial");
+			});
+		});
 	});
 
 	describe("setDoubleClickToZoom", () => {

--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
@@ -52,6 +52,7 @@ export class TerraDrawMapLibreGLAdapter<
 	private _prefixId: string;
 	private _initialDragPan: boolean | undefined;
 	private _initialDragRotate: boolean | undefined;
+	private _initialCursor: string | undefined;
 	private _isManagingDrag: boolean = false;
 	private _nextRender: number | undefined;
 	private _map: Map;
@@ -298,12 +299,21 @@ export class TerraDrawMapLibreGLAdapter<
 
 	/**
 	 * Sets the cursor style for the map container.
-	 * @param cursor The CSS cursor style to apply, or 'unset' to remove any previously applied cursor style.
+	 * @param cursor The CSS cursor style to apply, or 'unset' to restore the initial cursor style.
 	 */
 	public setCursor(cursor: Parameters<SetCursor>[0]) {
 		const canvas = this._map.getCanvas();
+
+		if (this._initialCursor === undefined && cursor !== "unset") {
+			this._initialCursor = canvas.style.cursor;
+		}
+
 		if (cursor === "unset") {
-			canvas.style.removeProperty("cursor");
+			if (this._initialCursor) {
+				canvas.style.cursor = this._initialCursor;
+			} else {
+				canvas.style.removeProperty("cursor");
+			}
 		} else {
 			canvas.style.cursor = cursor;
 		}


### PR DESCRIPTION
## Description of Changes

Map cursor styles get clobbered by terra-draw. If you have a custom cursor style set, whenever `setCursor('unset')` was called, it would remove any custom styles set by terra-draw, but wouldn't restore the initial ones.

This change stores the cursor style from the map the first time a custom cursor is set. Unsetting then becomes restoring the original cursor style if it is available.

For it to work it does require that `setCursor('unset')` isn't called before a custom cursor is actually set. In that case it will still clobber the underlying map styles. This seems to work for what we need, but feels a bit horrible.