### PR TITLE
feat(terra-draw): on cursor change

### DIFF
--- a/FORK_FEATURES.md
+++ b/FORK_FEATURES.md
@@ -18,25 +18,7 @@ full commit history.
 
 ---
 
-## 2 — Cursor initial-state preservation (MapLibre adapter)
-
-**What:** `setCursor("unset")` restores the CSS cursor that was on the map canvas
-*before* terra-draw first set it, rather than blindly calling `removeProperty("cursor")`.
-
-**How:** A private `_initialCursor: string | undefined` field is populated on the
-first `setCursor` call. On `"unset"`, the field is restored (or `removeProperty` is
-called if it was never set).
-
-**Why:** Without this, switching out of draw mode leaves the canvas cursor as the
-browser default instead of whatever the host application had set (e.g. a custom
-drag cursor on the map).
-
-**Files:** `packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts`
-**Upstream state:** Upstream calls `removeProperty` only — does not preserve initial cursor.
-
----
-
-## 3 — Lazy-snapshot draggability (MapLibre adapter)
+## 2 — Lazy-snapshot draggability (MapLibre adapter)
 
 **What:** `setDraggability(false)` captures the current state of `dragPan` and
 `dragRotate` **at the moment it is first called**, not at adapter construction time.
@@ -55,7 +37,7 @@ re-enable dragging.
 
 ---
 
-## 4 — Per-layer render ordering (MapLibre adapter)
+## 3 — Per-layer render ordering (MapLibre adapter)
 
 **What:** The MapLibre adapter accepts three independent `renderBelowLayerId`
 options — one per geometry type — instead of upstream's single field that moves
@@ -77,7 +59,7 @@ for example.
 
 ---
 
-## 5 — `pointerDistance / 2` click threshold (select mode)
+## 4 — `pointerDistance / 2` click threshold (select mode)
 
 **What:** Vertex drag-start fires only when the pointer is within
 `pointerDistance / 2` pixels of a vertex, not the full `pointerDistance`.
@@ -94,7 +76,7 @@ visible handle size rather than extending invisibly beyond it.
 
 ---
 
-## 6 — Configurable `zIndex` styling (polygon, linestring, select modes)
+## 5 — Configurable `zIndex` styling (polygon, linestring, select modes)
 
 **What:** Each mode's styling interface exposes a `zIndex: NumericStyling` property
 so callers can control draw-layer stacking order.
@@ -112,23 +94,13 @@ the styling interface.
 
 ---
 
-## 7 — `"default"` in `SetCursor` union
-
-**What:** `"default"` is a valid value for `SetCursor` / `Cursor`.
-
-**Files:** `packages/terra-draw/src/common.ts`,
-`packages/terra-draw/src/terra-draw.extensions.spec.ts`
-
-**Upstream state:** Not in the union.
-
----
-
-## 8 — `onCursorChange` callback (MapLibre adapter)
+## 6 — `onCursorChange` callback (MapLibre adapter)
 
 **What:** The MapLibre adapter accepts an optional `onCursorChange` callback. When
 provided, `setCursor` forwards every cursor intent (including `"unset"`) to the
 callback and does **not** mutate `map.getCanvas().style.cursor`. When omitted, the
-adapter falls back to its existing DOM-mutating behaviour (feature #2).
+adapter falls back to upstream's DOM-mutating behaviour (`canvas.style.cursor = …`
+and `removeProperty("cursor")` on `"unset"`).
 
 **Option:**
 - `onCursorChange?: (cursor: Parameters<SetCursor>[0]) => void`
@@ -142,3 +114,13 @@ stack) while preserving Terra Draw's cursor affordances.
 
 **Files:** `packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts`
 **Upstream state:** No callback — `setCursor` always mutates the canvas directly.
+
+**Removed fork feature:** A prior fork-only `_initialCursor` preservation on
+`"unset"` was dropped in v1.5.0 — it was a partial fix that did not work reliably
+when the host managed cursor state outside Terra Draw. Use `onCursorChange` instead.
+
+**Removed fork feature:** `"default"` in the `SetCursor` union was dropped — it
+existed only so consumers could configure mode cursors (e.g.
+`pointerOverCoordinate: 'default'`) as a workaround for cursor clobbering. With
+`onCursorChange`, Terra Draw emits `"unset"` and the host resolves its own
+fallback cursor.

--- a/FORK_FEATURES.md
+++ b/FORK_FEATURES.md
@@ -120,3 +120,25 @@ the styling interface.
 `packages/terra-draw/src/terra-draw.extensions.spec.ts`
 
 **Upstream state:** Not in the union.
+
+---
+
+## 8 — `onCursorChange` callback (MapLibre adapter)
+
+**What:** The MapLibre adapter accepts an optional `onCursorChange` callback. When
+provided, `setCursor` forwards every cursor intent (including `"unset"`) to the
+callback and does **not** mutate `map.getCanvas().style.cursor`. When omitted, the
+adapter falls back to its existing DOM-mutating behaviour (feature #2).
+
+**Option:**
+- `onCursorChange?: (cursor: Parameters<SetCursor>[0]) => void`
+
+**Why:** Terra Draw manages cursor state for its own purposes (e.g. changing the
+cursor over a coordinate) by writing directly to the canvas, which clobbers any
+cursor management the host application performs outside Terra Draw. The callback
+lets the host treat Terra Draw's cursor changes as *intents* and resolve the final
+cursor through a single source of truth (e.g. a React `cursor` prop / priority
+stack) while preserving Terra Draw's cursor affordances.
+
+**Files:** `packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts`
+**Upstream state:** No callback — `setCursor` always mutates the canvas directly.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,59 @@
 # Migration Guide — `@blocktype-co-uk/terra-draw`
 
+## v1.5.0 (`@blocktype-co-uk/terra-draw-maplibre-gl-adapter`)
+
+### Initial cursor preservation removed — use `onCursorChange`
+
+The fork previously restored the canvas cursor that existed *before* Terra Draw's
+first `setCursor` call when receiving `"unset"`. That behaviour was unreliable when
+the host application managed cursor state outside Terra Draw (e.g. via a React
+`cursor` prop).
+
+**Before (fork v1.4.x, no `onCursorChange`):**
+
+```ts
+new TerraDrawMapLibreGLAdapter({ map });
+// setCursor("unset") restored the pre-terra-draw canvas cursor
+```
+
+**After (v1.5.0+):**
+
+```ts
+new TerraDrawMapLibreGLAdapter({
+  map,
+  onCursorChange: (cursor) => {
+    // Forward Terra Draw's cursor intents into your own cursor state
+  },
+});
+```
+
+When `onCursorChange` is omitted, `"unset"` now matches upstream: it calls
+`removeProperty("cursor")` on the canvas rather than restoring a saved value.
+
+### `"default"` removed from `SetCursor` / mode cursor options
+
+The fork previously allowed `"default"` as a `SetCursor` value so mode cursor
+options like `pointerOverCoordinate: 'default'` could suppress Terra Draw's
+built-in cursor changes. That was another partial workaround for cursor clobbering.
+
+**Before:**
+
+```ts
+new TerraDrawSelectMode({
+  cursors: {
+    pointerOverCoordinate: 'default',
+    pointerOver: 'default',
+  },
+});
+```
+
+**After:**
+
+Remove those overrides and use `onCursorChange` on the adapter instead. Terra Draw
+will emit its natural cursor intents (`grab`, `pointer`, `move`, etc.) and
+`"unset"` when the pointer leaves; your host cursor state resolves the final
+cursor.
+
 ## v1.30.0
 
 ### `cursors.pointerOverSelectionPoint` renamed to `cursors.pointerOverCoordinate`

--- a/packages/terra-draw-maplibre-gl-adapter/CHANGELOG.md
+++ b/packages/terra-draw-maplibre-gl-adapter/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file. See [commit
 
 * **terra-draw-maplibre-gl-adapter:** add onCursorChange callback to delegate cursor control ([d6b32f7](https://github.com/blocktype-co-uk/terra-draw/commit/d6b32f7e24cdae3192c64258e9afb31a15e77370))
 
+
+### refactor
+
+* **terra-draw-maplibre-gl-adapter:** remove initial cursor preservation on unset (superseded by onCursorChange)
+* **terra-draw:** remove `"default"` from `SetCursor` union (superseded by onCursorChange)
+
 ## [1.4.1](https://github.com/JamesLMilner/terra-draw/compare/terra-draw-maplibre-gl-adapter@1.4.0...terra-draw-maplibre-gl-adapter@1.4.1) (2026-05-17)
 
 

--- a/packages/terra-draw-maplibre-gl-adapter/CHANGELOG.md
+++ b/packages/terra-draw-maplibre-gl-adapter/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [1.5.0](https://github.com/blocktype-co-uk/terra-draw/compare/terra-draw-maplibre-gl-adapter@1.4.1...terra-draw-maplibre-gl-adapter@1.5.0) (2026-06-15)
+
+
+### feat
+
+* **terra-draw-maplibre-gl-adapter:** add onCursorChange callback to delegate cursor control ([d6b32f7](https://github.com/blocktype-co-uk/terra-draw/commit/d6b32f7e24cdae3192c64258e9afb31a15e77370))
+
 ## [1.4.1](https://github.com/JamesLMilner/terra-draw/compare/terra-draw-maplibre-gl-adapter@1.4.0...terra-draw-maplibre-gl-adapter@1.4.1) (2026-05-17)
 
 

--- a/packages/terra-draw-maplibre-gl-adapter/package.json
+++ b/packages/terra-draw-maplibre-gl-adapter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blocktype-co-uk/terra-draw-maplibre-gl-adapter",
-	"version": "1.4.1",
+	"version": "1.5.0",
 	"description": "Terra Draw Adapter for Maplibre GL JS",
 	"peerDependencies": {
 		"@blocktype-co-uk/terra-draw": "^1.0.0",

--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
@@ -312,7 +312,7 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 		});
 
 		describe("when a cursor is set and then unset", () => {
-			it("restores the initial cursor", () => {
+			it("clears the inline cursor style", () => {
 				const map = createMapLibreGLMap();
 				const adapter = new TerraDrawMapLibreGLAdapter({
 					map: map as maplibregl.Map,
@@ -330,7 +330,7 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 				expect(container.style.cursor).toBe("pointer");
 
 				adapter.setCursor("unset");
-				expect(container.style.cursor).toBe("initial");
+				expect(container.style.removeProperty).toHaveBeenCalledWith("cursor");
 			});
 		});
 

--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.spec.ts
@@ -333,6 +333,38 @@ describe("TerraDrawMapLibreGLAdapter", () => {
 				expect(container.style.cursor).toBe("initial");
 			});
 		});
+
+		describe("when an onCursorChange callback is provided", () => {
+			it("forwards the cursor intent to the callback instead of touching the canvas", () => {
+				const map = createMapLibreGLMap();
+				const onCursorChange = jest.fn();
+				const adapter = new TerraDrawMapLibreGLAdapter({
+					map: map as maplibregl.Map,
+					onCursorChange,
+				});
+
+				const container = {
+					offsetLeft: 0,
+					offsetTop: 0,
+					style: { removeProperty: jest.fn(), cursor: "initial" },
+				} as unknown as HTMLCanvasElement;
+
+				map.getCanvas = jest.fn(() => container);
+
+				adapter.setCursor("pointer");
+				expect(onCursorChange).toHaveBeenCalledTimes(1);
+				expect(onCursorChange).toHaveBeenLastCalledWith("pointer");
+
+				adapter.setCursor("unset");
+				expect(onCursorChange).toHaveBeenCalledTimes(2);
+				expect(onCursorChange).toHaveBeenLastCalledWith("unset");
+
+				// Canvas cursor is left untouched — the host owns rendering.
+				expect(map.getCanvas).not.toHaveBeenCalled();
+				expect(container.style.cursor).toBe("initial");
+				expect(container.style.removeProperty).not.toHaveBeenCalled();
+			});
+		});
 	});
 
 	describe("setDoubleClickToZoom", () => {

--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
@@ -91,7 +91,6 @@ export class TerraDrawMapLibreGLAdapter<
 	private _prefixId: string;
 	private _initialDragPan: boolean | undefined;
 	private _initialDragRotate: boolean | undefined;
-	private _initialCursor: string | undefined;
 	private _isManagingDrag: boolean = false;
 	private _nextRender: number | undefined;
 	private _map: MaplibreMap;
@@ -432,7 +431,7 @@ export class TerraDrawMapLibreGLAdapter<
 
 	/**
 	 * Sets the cursor style for the map container.
-	 * @param cursor The CSS cursor style to apply, or 'unset' to restore the initial cursor style.
+	 * @param cursor The CSS cursor style to apply, or 'unset' to clear the inline cursor style.
 	 */
 	public setCursor(cursor: Parameters<SetCursor>[0]) {
 		// When a host application opts in via `onCursorChange`, it takes ownership of
@@ -445,16 +444,8 @@ export class TerraDrawMapLibreGLAdapter<
 
 		const canvas = this._map.getCanvas();
 
-		if (this._initialCursor === undefined && cursor !== "unset") {
-			this._initialCursor = canvas.style.cursor;
-		}
-
 		if (cursor === "unset") {
-			if (this._initialCursor) {
-				canvas.style.cursor = this._initialCursor;
-			} else {
-				canvas.style.removeProperty("cursor");
-			}
+			canvas.style.removeProperty("cursor");
 		} else {
 			canvas.style.cursor = cursor;
 		}

--- a/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
+++ b/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts
@@ -18,9 +18,9 @@ import {
 } from "maplibre-gl";
 import { Feature, LineString, Point, Polygon } from "geojson";
 
-export class TerraDrawMapLibreGLAdapter<MapType>
-	extends TerraDrawExtend.TerraDrawBaseAdapter
-{
+export class TerraDrawMapLibreGLAdapter<
+	MapType,
+> extends TerraDrawExtend.TerraDrawBaseAdapter {
 	constructor(
 		config: {
 			map: MapType;
@@ -29,6 +29,7 @@ export class TerraDrawMapLibreGLAdapter<MapType>
 			renderLinesBelowLayerId?: string;
 			renderPolygonsBelowLayerId?: string;
 			prefixId?: string;
+			onCursorChange?: (cursor: Parameters<SetCursor>[0]) => void;
 		} & TerraDrawExtend.BaseAdapterConfig,
 	) {
 		super(config);
@@ -44,6 +45,7 @@ export class TerraDrawMapLibreGLAdapter<MapType>
 			config.renderPolygonsBelowLayerId ?? config.renderBelowLayerId;
 
 		this._prefixId = config.prefixId || "td";
+		this._onCursorChange = config.onCursorChange;
 	}
 
 	// Per-layer render ordering (fork extension — allows finer-grained control than
@@ -94,6 +96,9 @@ export class TerraDrawMapLibreGLAdapter<MapType>
 	private _nextRender: number | undefined;
 	private _map: MaplibreMap;
 	private _container: HTMLElement;
+	private _onCursorChange:
+		| ((cursor: Parameters<SetCursor>[0]) => void)
+		| undefined;
 
 	private toGlDashArrayFromPixels(
 		dash: [number, number] | undefined,
@@ -430,6 +435,14 @@ export class TerraDrawMapLibreGLAdapter<MapType>
 	 * @param cursor The CSS cursor style to apply, or 'unset' to restore the initial cursor style.
 	 */
 	public setCursor(cursor: Parameters<SetCursor>[0]) {
+		// When a host application opts in via `onCursorChange`, it takes ownership of
+		// cursor rendering (e.g. so a single source of truth drives the map cursor).
+		// Terra Draw then only emits its intent and never mutates the canvas directly.
+		if (this._onCursorChange) {
+			this._onCursorChange(cursor);
+			return;
+		}
+
 		const canvas = this._map.getCanvas();
 
 		if (this._initialCursor === undefined && cursor !== "unset") {

--- a/packages/terra-draw/src/common.ts
+++ b/packages/terra-draw/src/common.ts
@@ -74,7 +74,6 @@ export type SetCursor = (
 		| "crosshair"
 		| "pointer"
 		| "wait"
-		| "default"
 		| "move",
 ) => void;
 

--- a/packages/terra-draw/src/terra-draw.extensions.spec.ts
+++ b/packages/terra-draw/src/terra-draw.extensions.spec.ts
@@ -132,7 +132,6 @@ export class TerraDrawTestAdapter extends TerraDrawBaseAdapter {
 		_:
 			| "move"
 			| "unset"
-			| "default"
 			| "grab"
 			| "grabbing"
 			| "crosshair"
@@ -170,9 +169,8 @@ export class TerraDrawTestAdapter extends TerraDrawBaseAdapter {
  * custom draw modes for Terra Draw exclusively relying on the public API of the library.
  */
 
-interface TerraDrawTestModeOptions<
-	T extends CustomStyling,
-> extends TerraDrawExtend.BaseModeOptions<T> {
+interface TerraDrawTestModeOptions<T extends CustomStyling>
+	extends TerraDrawExtend.BaseModeOptions<T> {
 	customProperty: string;
 }
 

--- a/packages/terra-draw/src/test/test-adapter.ts
+++ b/packages/terra-draw/src/test/test-adapter.ts
@@ -61,8 +61,7 @@ export class TerraDrawTestAdapter extends TerraDrawBaseAdapter {
 			| "grabbing"
 			| "crosshair"
 			| "pointer"
-			| "wait"
-			| "default",
+			| "wait",
 	): ReturnType<SetCursor> {
 		// pass
 	}
@@ -95,9 +94,8 @@ export class TerraDrawTestAdapter extends TerraDrawBaseAdapter {
  * custom draw modes for Terra Draw exclusively relying on the public API of the library.
  */
 
-interface TerraDrawTestModeOptions<
-	T extends CustomStyling,
-> extends TerraDrawExtend.BaseModeOptions<T> {
+interface TerraDrawTestModeOptions<T extends CustomStyling>
+	extends TerraDrawExtend.BaseModeOptions<T> {
 	customProperty: string;
 }
 


### PR DESCRIPTION
## `onCursorChange` callback (MapLibre adapter)

**What:** The MapLibre adapter accepts an optional `onCursorChange` callback. When provided, `setCursor` forwards every cursor intent (including `"unset"`) to the callback and does **not** mutate `map.getCanvas().style.cursor`. When omitted, the adapter falls back to its existing DOM-mutating behaviour.

**Option:**
- `onCursorChange?: (cursor: Parameters<SetCursor>[0]) => void`

**Why:** Terra Draw manages cursor state for its own purposes (e.g. changing the cursor over a coordinate) by writing directly to the canvas, which clobbers any cursor management the host application performs outside Terra Draw. The callback lets the host treat Terra Draw's cursor changes as *intents* and resolve the final cursor through a single source of truth (e.g. a React `cursor` prop / priority stack) while preserving Terra Draw's cursor affordances.

This approach also lets us get rid of some of the old fork behaviour we had around cursor management that only partially solved the problem.